### PR TITLE
Fixes Linux DNS test failure

### DIFF
--- a/client/dns/dns_test.go
+++ b/client/dns/dns_test.go
@@ -1,11 +1,12 @@
 package dns
 
 import (
+	"fmt"
 	"net"
 	"os/exec"
 	"runtime"
 	"testing"
-	"fmt"
+	"time"
 )
 
 // We only want to test for "Was the DNS configured properly?"
@@ -76,8 +77,12 @@ func TestGolangDNS(t *testing.T) {
 		t.Skip("Platform is not supported")
 	}
 	DNSLookupHelper(t, func() (err error) {
-		val, err := net.LookupIP("google.com")
-		fmt.Println(val)
+		_, err = net.LookupIP("google.com")
+		// This is an unfortunate side effect of the fact that Go checks the /etc/resolv.conf file
+		// once every 5 seconds.
+		// https://github.com/golang/go/blob/ad77cefeb2f5b3f1cef4383e974195ffc8610236/src/net/dnsclient_unix.go#L401
+		// TODO: work around this if you want to make the tests faster
+		time.Sleep(5 * time.Second)
 		return err
 	})
 }


### PR DESCRIPTION
Pretty straightforward. Makes the tests even more slow. Oh well. We can fix that one day. 

Closes #4 