### PR TITLE
Adds TLS to server components and fixes client error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+*.pem
+*.key

--- a/client/client.go
+++ b/client/client.go
@@ -14,7 +14,7 @@ var ctrlEndpoint string
 var proxyEndpoint string
 
 const defaultCtrlEndpoint string = "127.0.0.1:81"
-const defaultDNSEndpoint string = "127.0.0.1:53"
+const defaultDNSEndpoint string = "127.0.0.1"
 
 type defaultDns struct{}
 
@@ -63,15 +63,28 @@ func _main(dns DNSConfig, ctrlEndpoint string, arglen int, args []string) int {
 			fmt.Fprintf(os.Stderr, "Unrecognized arguments.\n")
 			return 1
 		}
-		dns.Config(dnsEndpoint)
-		dns.FlushCache()
+		err := dns.Config(dnsEndpoint)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to configure DNS: %s\n", err)
+		}
+		err = dns.FlushCache()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to flush DNS cache: %s\n", err)
+		}
+
 	case "deconfig":
 		if arglen != 1 {
 			fmt.Fprintf(os.Stderr, "Unrecognized arguments.\n")
 			return 1
 		}
-		dns.Deconfig()
-		dns.FlushCache()
+		err := dns.Deconfig()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to deconfigure DNS: %s\n", err)
+		}
+		err = dns.FlushCache()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to flush DNS cache: %s\n", err)
+		}
 	case "tag":
 		if arglen != 2 {
 			fmt.Fprintf(os.Stderr, "No tag given.\n")

--- a/server/main.go
+++ b/server/main.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	controllerServer := controller(wg, 5678)
+	controllerServer := controller(wg, 5678, true)
 	wg.Add(1)
 	proxyServer := proxy(wg, 1234)
 

--- a/server/main.go
+++ b/server/main.go
@@ -14,13 +14,16 @@ func main() {
 	wg.Add(1)
 	controllerServer := controller(wg, 5678, true)
 	wg.Add(1)
-	proxyServer := proxy(wg, 1234)
+	proxyServer := proxy(wg, 80, false)
+	wg.Add(1)
+	proxyServerTLS := proxy(wg, 443, true)
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	go func() {
 		// TODO: figure out this TODO business with the context
 		defer proxyServer.Shutdown(context.TODO())
+		defer proxyServerTLS.Shutdown(context.TODO())
 		defer controllerServer.Shutdown(context.TODO())
 		for sig := range c {
 			if sig == syscall.SIGINT {

--- a/server/tls.md
+++ b/server/tls.md
@@ -1,0 +1,8 @@
+# TLS for server endpoints
+For now, we need to generate self-signed certificates to test this with HTTPS.
+Just run the following commands in this directory:
+```
+openssl ecparam -genkey -name secp384r1 -out server.key
+openssl req -new -x509 -sha256 -key server.key -out server.pem -days 3650
+
+```


### PR DESCRIPTION
This branch adds TLS to server components. There is now an option to run TLS versions of both the controller and proxy. In the main function it runs both an HTTP proxy and HTTPS proxy. On ports 80 and 443 respectively. The controller runs TLS by default.

Adds a readme explaining how we are handling certs at the moment. Adds a gitignore entry to ignore these generated files.

Over the course of testing discovered some issues with the client configuration. Went ahead and fixed the reporting of errors here.

closes #13